### PR TITLE
Change queue import to be Python 2.7 compliant

### DIFF
--- a/migratelongerids.py
+++ b/migratelongerids.py
@@ -19,7 +19,7 @@ import threading
 import sys
 from time import sleep
 import logging
-from queue import Queue
+from Queue import Queue
 from botocore.client import Config
 # try fail-able imports and imports with versioning requirements
 try:


### PR DESCRIPTION
Trying to 'import queue' from Python 2.7.3 will throw an error as the module is named Queue (note capital).  In Python3 Queue got renamed to queue.

See http://www.diveintopython3.net/porting-code-to-python-3-with-2to3.html#othermodules

