### PR TITLE
Add --profile option

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ You can Combine Status to be used with revert and convertself and will output th
 `./migratelongerids.py --convertself --status` OR  
 `./migratelongerids.py --revert --status`  
 
+You can use the optional --profile PROFILE to specify a different profile to use from the ~/.aws/credentials file
+
 All possible usage combinations:  
 `--status`  
 `--convertonly`  
@@ -96,4 +98,4 @@ All possible usage combinations:
 `--revert --convertonly`  
 `--revert --convertself --convertonly`  
 `--convertself --status`  
-`--convertself --convertonly`  
+`--convertself --convertonly` 

--- a/migratelongerids.py
+++ b/migratelongerids.py
@@ -317,7 +317,8 @@ def main():
     --revert --status
     --revert --convertself --convertonly
     --convertself --status
-    --convertself --convertonly"""
+    --convertself --convertonly
+    [--profile]"""
 
     #Variables:
     clibool = True
@@ -339,8 +340,11 @@ def main():
                                                                    'end.')
     parser.add_argument('--convertself', action='store_true', help='This converts the single ARN in'
                                                                    'all regions.')
+    parser.add_argument('--profile', help='Use different profile credentials')
 
     args = parser.parse_args()
+
+    boto3.setup_default_session(profile_name=args.profile)
 
     arn = 'all'
     regions = getregions()


### PR DESCRIPTION
Users can specify the —profile parameter to use different set of credentials from ~/.aws/credentials